### PR TITLE
fix: pin claude-sonnet-4-6 model for phase 3

### DIFF
--- a/packages/core/src/pipeline/phase-3-implementation.ts
+++ b/packages/core/src/pipeline/phase-3-implementation.ts
@@ -18,6 +18,7 @@ export async function runPhase3(
         name: "phase-3-implementation",
         prompt: ctx.adapter.getPageBuilderPrompt(plan, ctx.screenshotDir, corrections),
         allowedTools: [...PHASE_3_TOOLS],
+        model: "claude-sonnet-4-6",
         timeout: 600_000,
         maxTurns: 50,
       },


### PR DESCRIPTION
## Summary

Adds explicit model specification to Phase 3 (implementation) to match all other phases.

## Problem

Phase 3 was the only phase without an explicit `model` parameter in its `runClaudePhase` config (lines 16-23). This caused it to use whatever the Claude CLI defaults to, leading to:

- **Unpredictable costs**: Phase 3 is the most expensive phase (`maxTurns: 50`, `timeout: 600_000`)
- **Inconsistent results** across different environments
- **Different behavior** with different Claude CLI versions

## Solution

Added `model: "claude-sonnet-4-6"` to the Phase 3 config, matching the explicit model specification in:
- Phase 0 (screenshot)
- Phase 1B (color extraction)
- Phase 2 (planning)
- Phase 4 (refinement)

## Changes

```diff
   const result = await runClaudePhase(
     {
       name: "phase-3-implementation",
       prompt: ctx.adapter.getPageBuilderPrompt(plan, ctx.screenshotDir, corrections),
       allowedTools: [...PHASE_3_TOOLS],
+      model: "claude-sonnet-4-6",
       timeout: 600_000,
       maxTurns: 50,
     },
```

Fixes #12